### PR TITLE
Fix the build with gcc10.

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #endif
 
+extern char *LPE_CONFIG_FILE;
 int cfg_errno;
 
 void

--- a/src/lpe.c
+++ b/src/lpe.c
@@ -25,6 +25,7 @@
 #include "strfuncs.h"
 #include "exports.h"
 
+char *LPE_CONFIG_FILE;
 /* A flag indicating a desire to quit the editor.  This is set whenever a
  * command should cause an exit.
  */

--- a/src/options.h
+++ b/src/options.h
@@ -38,6 +38,6 @@
 /*
  * Other things that are used in some places...
  */
-char *LPE_CONFIG_FILE;
+extern char *LPE_CONFIG_FILE;
 
 #endif /* LPE_OPTIONS_H */


### PR DESCRIPTION
When building lpe with gcc10 it fails.
```
make[2]: Entering directory '/tmp/lpe/src'
/bin/sh ../libtool  --tag=CC   --mode=link clang -DDATADIR=\"/usr/local/share/lpe\" -g -O2 -export-dynamic  -o lpe buffer.o cfg-core.o cfg.o exports.o genmode.o help.o input.o lpe.o lpecomm.o minibuf.o mode-utils.o screen.o strfuncs.o common.o -ldl -lslang -lncurses 
libtool: link: clang -DDATADIR=\"/usr/local/share/lpe\" -g -O2 -o lpe buffer.o cfg-core.o cfg.o exports.o genmode.o help.o input.o lpe.o lpecomm.o minibuf.o mode-utils.o screen.o strfuncs.o common.o -Wl,--export-dynamic  -ldl -lslang -lncurses
/usr/bin/ld: cfg.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: exports.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: genmode.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: help.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: input.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: lpe.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: lpecomm.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: minibuf.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: mode-utils.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
/usr/bin/ld: screen.o:/tmp/lpe/src/./options.h:41: multiple definition of `LPE_CONFIG_FILE'; buffer.o:/tmp/lpe/src/./options.h:41: first defined here
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Makefile:535: lpe] Error 1
make[2]: Leaving directory '/tmp/lpe/src'
make[1]: *** [Makefile:598: install-recursive] Error 1
make[1]: Leaving directory '/tmp/lpe/src'
make: *** [Makefile:524: install-recursive] Error 1
```
Gentoo already carries a patch to fix this which can be applied.

https://gitweb.gentoo.org/repo/gentoo.git/tree/app-editors/lpe/files/lpe-1.2.6.13-fno-common.patch