### PR TITLE
modes: Remove -no-undefined.

### DIFF
--- a/src/modes/Makefile.am
+++ b/src/modes/Makefile.am
@@ -1,6 +1,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
 AM_CFLAGS = -I$(top_srcdir)/src
+AM_LDFLAGS = -avoid-version -module -export-dynamic -rpath $(liblpedir)
 
 liblpedir = $(libdir)/lpe
 
@@ -11,18 +12,10 @@ EXTRA_LTLIBRARIES = \
 	mailmode.la javamode.la lispmode.la
 
 cmode_la_SOURCES = cmode.c
-cmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 cppmode_la_SOURCES = cppmode.c
-cppmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 perlmode_la_SOURCES = perlmode.c
-perlmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 htmlmode_la_SOURCES = htmlmode.c
-htmlmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 sgmlmode_la_SOURCES = sgmlmode.c
-sgmlmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 mailmode_la_SOURCES = mailmode.c
-mailmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 javamode_la_SOURCES = javamode.c
-javamode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)
 lispmode_la_SOURCES = lispmode.c
-lispmode_la_LDFLAGS = -no-undefined -avoid-version -module -export-dynamic -rpath $(liblpedir)


### PR DESCRIPTION
Alternative fix for https://github.com/AdamMajer/lpe/pull/3.

Since these symbols will be resolved in the main binary and not during the build its best to not use `-no-undefined`.

Closes: https://github.com/AdamMajer/lpe/pull/3